### PR TITLE
Fix snarkjs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,6 @@
   "dependencies": {
     "circom": "0.0.28",
     "markdown-toc": "^1.2.0",
-    "snarkjs": "^0.1.13"
+    "snarkjs": "0.1.13"
   }
 }


### PR DESCRIPTION
The error happened when I executed `snarkjs calculatewitness -c circuit.json -i input.json` as following.
```
(base) ➜  RollupNC_tutorial git:(fix-snarkjs-version) ✗ yarn snarkjs calculatewitness -c 1_simple_arithmetic/circuit.json -i 1_simple_arithmetic/input.json
yarn run v1.21.1
$ snarkjs calculatewitness -c 1_simple_arithmetic/circuit.json -i 1_simple_arithmetic/input.json
Error: ENOENT: no such file or directory, open 'circuit.wasm'
ERROR: Error: ENOENT: no such file or directory, open 'circuit.wasm'
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```
It's necessary to fix the snarkjs version `0.1.13`.